### PR TITLE
Resolve conflict with windef.h macros and remove implicit cast

### DIFF
--- a/source/reflectionzeug/include/reflectionzeug/NumberProperty.hpp
+++ b/source/reflectionzeug/include/reflectionzeug/NumberProperty.hpp
@@ -10,18 +10,18 @@ template <typename Type>
 NumberProperty<Type>::NumberProperty(const std::string & name, const Type & value)
 :   ValuePropertyTemplate<Type>(name, value)
 ,   m_min(std::numeric_limits<Type>::lowest())
-,   m_max(std::numeric_limits<Type>::max())
+,   m_max((std::numeric_limits<Type>::max)())
 ,   m_step(0)
 {
 }
 
 template <typename Type>
-NumberProperty<Type>::NumberProperty(const std::string & name, 
+NumberProperty<Type>::NumberProperty(const std::string & name,
     const std::function<Type ()> & getter,
     const std::function<void(const Type &)> & setter)
 :   ValuePropertyTemplate<Type>(name, getter, setter)
 ,   m_min(std::numeric_limits<Type>::lowest())
-,   m_max(std::numeric_limits<Type>::max())
+,   m_max((std::numeric_limits<Type>::max)())
 ,   m_step(0)
 {
 }
@@ -33,7 +33,7 @@ NumberProperty<Type>::NumberProperty(const std::string & name,
     void (Object::*setter_pointer)(const Type &))
 :   ValuePropertyTemplate<Type>(name, object, getter_pointer, setter_pointer)
 ,   m_min(std::numeric_limits<Type>::lowest())
-,   m_max(std::numeric_limits<Type>::max())
+,   m_max((std::numeric_limits<Type>::max)())
 ,   m_step(0)
 {
 }
@@ -45,7 +45,7 @@ NumberProperty<Type>::NumberProperty(const std::string & name,
     void (Object::*setter_pointer)(const Type &))
 :   ValuePropertyTemplate<Type>(name, object, getter_pointer, setter_pointer)
 ,   m_min(std::numeric_limits<Type>::lowest())
-,   m_max(std::numeric_limits<Type>::max())
+,   m_max((std::numeric_limits<Type>::max)())
 ,   m_step(0)
 {
 }
@@ -81,11 +81,11 @@ void NumberProperty<Type>::setMaximum(const Type & maximum)
     m_max = maximum;
     // this->m_announcer.notify(events::kRangeChanged);
 }
-    
+
 template <typename Type>
 bool NumberProperty<Type>::hasMaximum() const
 {
-    return m_max != std::numeric_limits<Type>::max();
+    return m_max != (std::numeric_limits<Type>::max)();
 }
 
 template <typename Type>

--- a/source/scriptzeug/source/BackendJavaScript/JSPropVisitor.cpp
+++ b/source/scriptzeug/source/BackendJavaScript/JSPropVisitor.cpp
@@ -115,7 +115,7 @@ void JSPropVisitor::visit(Property<std::vector<double>> & property)
         }
     } else {
         std::vector<double> arr;
-        for (double i=0; i<m_value.size(); i++) {
+        for (unsigned int i=0; i<m_value.size(); i++) {
             arr.push_back(m_value[i].toDouble());
         }
         property.setValue(arr);


### PR DESCRIPTION
As soon as windef.h is included in a project (or another file which defines the max-macro), the existing calls to std::numeric_limits<Type>::max won't compile. I added defensive parenthesis to resolve this conflict.
