### PR TITLE
Add handling of script errors/exceptions via signal (ref #43)

### DIFF
--- a/source/examples/script/main.cpp
+++ b/source/examples/script/main.cpp
@@ -115,6 +115,12 @@ int main(int argc, char const *argv[])
     MyInterface obj;
 
     ScriptContext scripting;
+    scripting.scriptException.connect( [] (const std::string & error) -> void {
+        std::cout << "-- EXCEPTION --\n";
+        std::cout << error << "\n";
+        std::cout << "-- EXCEPTION --\n";
+    });
+
     scripting.registerObject(&obj);
 
     Variant value;
@@ -152,6 +158,12 @@ int main(int argc, char const *argv[])
     value = scripting.evaluate("api.counting.min = 5;");
     value = scripting.evaluate("api.counting.max = 10;");
     value = scripting.evaluate("api.counting.count();");
+    std::cout << "--> " << value.toString() << "\n";
+
+    value = scripting.evaluate("api.noFunction();");
+    std::cout << "--> " << value.toString() << "\n";
+
+    value = scripting.evaluate("asd");
     std::cout << "--> " << value.toString() << "\n";
 
     return 0;

--- a/source/scriptzeug/include/scriptzeug/Backend/AbstractScriptContext.h
+++ b/source/scriptzeug/include/scriptzeug/Backend/AbstractScriptContext.h
@@ -15,16 +15,22 @@ namespace scriptzeug
 {
 
 
+class ScriptContext;
+
+
 /** \brief Base class for backend specific scripting contexts
  */
 class SCRIPTZEUG_API AbstractScriptContext
 {
 public:
-    AbstractScriptContext();
+    AbstractScriptContext(ScriptContext * scriptContext);
     virtual ~AbstractScriptContext();
 
     virtual void registerObject(reflectionzeug::PropertyGroup * obj) = 0;
     virtual reflectionzeug::Variant evaluate(const std::string & code) = 0;
+
+protected:
+	ScriptContext * m_scriptContext; /**< Script context holding this backend */
 };
 
 

--- a/source/scriptzeug/include/scriptzeug/BackendJavaScript/JSScriptContext.h
+++ b/source/scriptzeug/include/scriptzeug/BackendJavaScript/JSScriptContext.h
@@ -14,7 +14,7 @@ namespace scriptzeug
 class SCRIPTZEUG_API JSScriptContext : public AbstractScriptContext
 {
 public:
-    JSScriptContext();
+    JSScriptContext(ScriptContext * scriptContext);
     virtual ~JSScriptContext();
 
     virtual void registerObject(reflectionzeug::PropertyGroup * obj);

--- a/source/scriptzeug/include/scriptzeug/ScriptContext.h
+++ b/source/scriptzeug/include/scriptzeug/ScriptContext.h
@@ -2,6 +2,7 @@
 
 
 #include <string>
+#include <signalzeug/Signal.h>
 #include <reflectionzeug/Variant.h>
 #include "scriptzeug/scriptzeug.h"
 
@@ -22,6 +23,9 @@ class AbstractScriptContext;
  */
 class SCRIPTZEUG_API ScriptContext
 {
+public:
+    signalzeug::Signal<const std::string &> scriptException;
+
 public:
     ScriptContext(const std::string & backend = "javascript");
     virtual ~ScriptContext();

--- a/source/scriptzeug/source/Backend/AbstractScriptContext.cpp
+++ b/source/scriptzeug/source/Backend/AbstractScriptContext.cpp
@@ -5,7 +5,8 @@ namespace scriptzeug
 {
 
 
-AbstractScriptContext::AbstractScriptContext()
+AbstractScriptContext::AbstractScriptContext(ScriptContext * scriptContext)
+: m_scriptContext(scriptContext)
 {
 }
 

--- a/source/scriptzeug/source/ScriptContext.cpp
+++ b/source/scriptzeug/source/ScriptContext.cpp
@@ -16,7 +16,7 @@ ScriptContext::ScriptContext(const std::string & backend)
     // Create backend
 #ifdef LIBZEUG_USE_V8
     if (backend == "javascript")
-        m_backend = new JSScriptContext();
+        m_backend = new JSScriptContext(this);
 #endif
 }
 


### PR DESCRIPTION
First take on #43 : Script exceptions can be caught by connecting to a signal.

In addition to that, I could think about adding an optional output argument to evaluate, e.g.,
  Variant evaluate(const std::string & code, ScriptError \* error = nullptr).

Thoughts?
