### PR TITLE
fixes a windows problem

### DIFF
--- a/source/propertyguizeug/CMakeLists.txt
+++ b/source/propertyguizeug/CMakeLists.txt
@@ -5,7 +5,6 @@ message(STATUS "Lib ${target}")
 #
 # External libraries
 #
-find_package(Qt5        REQUIRED)
 find_package(Qt5Core    REQUIRED)
 find_package(Qt5Gui     REQUIRED)
 find_package(Qt5Widgets REQUIRED)


### PR DESCRIPTION
the line causes my windows qt5.3.0 x64 to say:

CMake Error at source/propertyguizeug/CMakeLists.txt:8 (find_package):
  Found package configuration file:

```
D:/Qt/Qt5.3.0/5.3/msvc2013_64_opengl/lib/cmake/Qt5/Qt5Config.cmake
```

  but it set Qt5_FOUND to FALSE so package "Qt5" is considered to be NOT
  FOUND.  Reason given by package:

  The Qt5 package requires at least one component
