### PR TITLE
fix unreferenced formal parameter warning in Signal.hpp

### DIFF
--- a/source/signalzeug/include/signalzeug/Signal.hpp
+++ b/source/signalzeug/include/signalzeug/Signal.hpp
@@ -60,7 +60,7 @@ Connection Signal<Arguments...>::connect(Signal& signal) const
 template <typename... Arguments>
 Connection Signal<Arguments...>::onFire(std::function<void()> callback) const
 {
-	return connect([callback](Arguments... arguments) 
+	return connect([callback](Arguments... /*arguments*/) 
 	{
 		callback();
 	});


### PR DESCRIPTION
This fixes a C4100 in Signal.hpp for MSVC.
