### PR TITLE
Option to set string based on hightlighted entry in a ComboBox

### DIFF
--- a/source/propertyguizeug/source/StringEditor.cpp
+++ b/source/propertyguizeug/source/StringEditor.cpp
@@ -43,13 +43,10 @@ QWidget * StringEditor::createComboBox()
     if (m_property->hasOption("highlightActiviation"))
     {
         connect(comboBox, static_cast<StringActivatedPtr>(&QComboBox::highlighted),
-        this, &StringEditor::setString);
+                this, &StringEditor::setString);
     }
-    else
-    {
-        connect(comboBox, static_cast<StringActivatedPtr>(&QComboBox::activated),
-        this, &StringEditor::setString);
-    }
+    connect(comboBox, static_cast<StringActivatedPtr>(&QComboBox::activated),
+            this, &StringEditor::setString);
 
     m_propertyChangedConnection = m_property->valueChanged.connect(
         [this, comboBox]()

--- a/source/propertyguizeug/source/StringEditor.cpp
+++ b/source/propertyguizeug/source/StringEditor.cpp
@@ -40,7 +40,7 @@ QWidget * StringEditor::createComboBox()
     comboBox->setCurrentText(QString::fromStdString(m_property->toString()));
     
     using StringActivatedPtr = void (QComboBox::*) (const QString &);
-    if (m_property->hasOption("highlightActiviation"))
+    if (m_property->hasOption("highlightActivation"))
     {
         connect(comboBox, static_cast<StringActivatedPtr>(&QComboBox::highlighted),
                 this, &StringEditor::setString);

--- a/source/propertyguizeug/source/StringEditor.cpp
+++ b/source/propertyguizeug/source/StringEditor.cpp
@@ -40,8 +40,16 @@ QWidget * StringEditor::createComboBox()
     comboBox->setCurrentText(QString::fromStdString(m_property->toString()));
     
     using StringActivatedPtr = void (QComboBox::*) (const QString &);
-    connect(comboBox, static_cast<StringActivatedPtr>(&QComboBox::activated),
-            this, &StringEditor::setString);
+    if (m_property->hasOption("highlightActiviation"))
+    {
+        connect(comboBox, static_cast<StringActivatedPtr>(&QComboBox::highlighted),
+        this, &StringEditor::setString);
+    }
+    else
+    {
+        connect(comboBox, static_cast<StringActivatedPtr>(&QComboBox::activated),
+        this, &StringEditor::setString);
+    }
 
     m_propertyChangedConnection = m_property->valueChanged.connect(
         [this, comboBox]()


### PR DESCRIPTION
If you quickly want to select options for a string property, it is easier to set the string based on the currently highlighted item. No need to open the ComboBox several times to select one choice after the other.

This is only done if the Option "highlightActiviation" is set.