### PR TITLE
Fix compilation on gcc 4.8.2

### DIFF
--- a/source/reflectionzeug/source/util.cpp
+++ b/source/reflectionzeug/source/util.cpp
@@ -79,7 +79,7 @@ std::string trim(const std::string & string, bool enclosed)
 {
     const regex_namespace::regex regex(enclosed ? "\\s+" : "(^\\s+|\\s+$)");
     
-    return regex_namespace::regex_replace(string, regex, "");
+    return regex_namespace::regex_replace(string, regex, std::string(""));
 }
 
 std::vector<std::string> splitArray(size_t size, const std::string & string)


### PR DESCRIPTION
GCC 4.8.2 complains about the following otherwise:

```
<...>/libzeug/source/reflectionzeug/source/util.cpp: In function ‘std::string reflectionzeug::util::trim(const string&, bool)’:
<...>/libzeug/source/reflectionzeug/source/util.cpp:82:60: error: no matching function for call to ‘regex_replace(const string&, const regex&, const char [1])’
     return regex_namespace::regex_replace(string, regex, "");
                                                            ^
<...>/libzeug/source/reflectionzeug/source/util.cpp:82:60: note: candidates are:
In file included from /usr/include/c++/4.8/regex:62:0,
                 from <...>/libzeug/source/reflectionzeug/source/util.cpp:4:
/usr/include/c++/4.8/bits/regex.h:2162:5: note: template<class _Out_iter, class _Bi_iter, class _Rx_traits, class _Ch_type> _Out_iter std::regex_replace(_Out_iter, _Bi_iter, _Bi_iter, const std::basic_regex<_Ch_type, _Rx_traits>&, const std::basic_string<_Ch_type>&, std::regex_constants::match_flag_type)
     regex_replace(_Out_iter __out, _Bi_iter __first, _Bi_iter __last,
     ^
/usr/include/c++/4.8/bits/regex.h:2162:5: note:   template argument deduction/substitution failed:
<...>/libzeug/source/reflectionzeug/source/util.cpp:82:60: note:   deduced conflicting types for parameter ‘_Bi_iter’ (‘std::basic_regex<char>’ and ‘const char*’)
     return regex_namespace::regex_replace(string, regex, "");
                                                            ^
In file included from /usr/include/c++/4.8/regex:62:0,
                 from <...>/libzeug/source/reflectionzeug/source/util.cpp:4:
/usr/include/c++/4.8/bits/regex.h:2182:5: note: template<class _Rx_traits, class _Ch_type> std::basic_string<_Ch_type> std::regex_replace(const std::basic_string<_Ch_type>&, const std::basic_regex<_Ch_type, _Rx_traits>&, const std::basic_string<_Ch_type>&, std::regex_constants::match_flag_type)
     regex_replace(const basic_string<_Ch_type>& __s,
     ^
/usr/include/c++/4.8/bits/regex.h:2182:5: note:   template argument deduction/substitution failed:
<...>/libzeug/source/reflectionzeug/source/util.cpp:82:60: note:   mismatched types ‘const std::basic_string<_Ch_type>’ and ‘const char [1]’
     return regex_namespace::regex_replace(string, regex, "");
```